### PR TITLE
add -alpn option to specify a comma-separated list of application level protocols ("h2" for grpc, for example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ Simple command line secure tunneling tool.
 
 ## Usage
 ```
+  -alpn string
+    	Comma-separated list of supported application level protocols
   -cert string
     	Certificate file
   -key string
     	Key file
   -local string
     	Where to listen on this machine [ip_address]:port
-  -min-tls
-      Minimum TLS version (default: 1.3)
+  -min-tls string
+    	Minimum TLS version accepted (default "1.3")
   -remote string
     	Where to connect to {ip_address | hostname}:port
 ```

--- a/gosecure.go
+++ b/gosecure.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strings"
 	"sync"
 )
 
@@ -18,6 +19,7 @@ type Config struct {
 	local    string
 	remote   string
 	mintls   string
+	alpn     string
 }
 
 // This three values are changed from Makefile
@@ -48,6 +50,7 @@ func main() {
 	flag.StringVar(&CONFIG.local, "local", "", "Where to listen on this machine [ip_address]:port")
 	flag.StringVar(&CONFIG.remote, "remote", "", "Where to connect to {ip_address | hostname}:port")
 	flag.StringVar(&CONFIG.mintls, "min-tls", "1.3", "Minimum TLS version accepted")
+	flag.StringVar(&CONFIG.alpn, "alpn", "", "Comma-separated list of supported application level protocols")
 
 	flag.Parse()
 
@@ -82,6 +85,7 @@ func main() {
 	config := &tls.Config{
 		Certificates: []tls.Certificate{cer},
 		MinVersion:   uint16(mintls),
+		NextProtos:   strings.Split(CONFIG.alpn, ","),
 	}
 	ln, err := tls.Listen("tcp", CONFIG.local, config)
 	if err != nil {


### PR DESCRIPTION
Thanks for the tool! I needed this small change to be able to tls-wrap a grpc server so that the client doesn't assume the wrapped server _doesn't_ support grpc.